### PR TITLE
fix: refetch invoices after mutation

### DIFF
--- a/src/client/features/invoice/invoice-form.tsx
+++ b/src/client/features/invoice/invoice-form.tsx
@@ -33,7 +33,7 @@ type Props = {
   kind: 'create' | 'update'
   onCancel?: () => void
   onSubmit: (data: CreateInvoiceRequest) => void
-  defaultValues?: CreateInvoiceRequest | UpdateInvoiceRequest
+  defaultValues?: Partial<CreateInvoiceRequest | UpdateInvoiceRequest>
   'aria-labelledby': string
 }
 
@@ -54,7 +54,7 @@ const defaultFormValues = {
     country: '',
   },
   issuedAt: new Date(), //format(new Date(), 'yyyy-MM-dd'),
-  paymentTermId: 0,
+  // paymentTermId: '',
   projectDescription: '',
   itemList: [],
   status: 'draft' as const,
@@ -73,7 +73,9 @@ export function InvoiceForm({
 
   const formattedDefaultValues = {
     ...defaultValues,
-    issuedAt: format(defaultValues.issuedAt, 'yyyy-MM-dd'),
+    issuedAt: defaultValues.issuedAt
+      ? format(defaultValues.issuedAt, 'yyyy-MM-dd')
+      : undefined,
   }
 
   const paymentTermsQuery = usePaymentTerms()
@@ -188,6 +190,7 @@ export function InvoiceForm({
           <Select
             className={spanHalf}
             label="Payment Terms"
+            errorMessage={errors.paymentTermId?.message}
             isLoading={paymentTermsQuery.isLoading}
             options={
               paymentTermsQuery.isSuccess

--- a/src/client/features/invoice/invoice.queries.ts
+++ b/src/client/features/invoice/invoice.queries.ts
@@ -102,6 +102,8 @@ export function useCreateInvoice({
           queryClient.getQueryData<Array<InvoiceSummary>>(invoiceKeys.list()) ??
           []
 
+        const queriesData = queryClient.getQueriesData(invoiceKeys.lists())
+
         const pendingId = `SAVING-${nanoid()}`
         if (previousInvoices) {
           queryClient.setQueryData<Array<InvoiceSummary>>(invoiceKeys.list(), [
@@ -134,6 +136,8 @@ export function useCreateInvoice({
             updatedInvoices
           )
         }
+
+        queryClient.invalidateQueries(invoiceKeys.lists())
 
         onSuccess?.(savedInvoiceDetail, _newInvoiceInput, context)
       },
@@ -187,6 +191,8 @@ export function useMarkAsPaid({
           invoiceKeys.detail(invoiceId),
           updatedInvoiceDetail
         )
+
+        queryClient.invalidateQueries(invoiceKeys.lists())
 
         onSuccess?.(updatedInvoiceDetail, invoiceId, context)
       },
@@ -242,6 +248,8 @@ export function useUpdateInvoice({
           invoiceKeys.detail(mutationProps.id),
           updatedInvoiceDetail
         )
+
+        queryClient.invalidateQueries(invoiceKeys.lists())
 
         onSuccess?.(updatedInvoiceDetail, mutationProps, context)
       },

--- a/src/client/shared/components/input/input.css.ts
+++ b/src/client/shared/components/input/input.css.ts
@@ -59,7 +59,7 @@ export const input = style({
   border: '1px solid',
   borderColor: 'inherit',
   outlineColor: 'inherit',
-  color: 'inherit',
+  color: themeVars.color.text.strong,
   borderRadius: '4px',
   fontWeight: themeVars.typography.fontWeight.bold,
 })

--- a/src/client/shared/components/select/select.css.ts
+++ b/src/client/shared/components/select/select.css.ts
@@ -59,7 +59,7 @@ export const select = style({
   border: '1px solid',
   borderColor: 'inherit',
   outlineColor: 'inherit',
-  color: 'inherit',
+  color: themeVars.color.text.strong,
   borderRadius: '4px',
   fontWeight: themeVars.typography.fontWeight.bold,
   lineHeight: themeVars.typography.body1.lineHeight,

--- a/src/client/shared/components/select/select.test.tsx
+++ b/src/client/shared/components/select/select.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 import { Select } from '.'
 import { randomPick } from 'src/shared/random'
@@ -49,7 +49,8 @@ it('should render all options when not loading', () => {
 
   const options = screen.getAllByRole('option')
 
-  expect(options).toHaveLength(defaultProps.options.length)
+  // we should have all the options, plus the empty one
+  expect(options).toHaveLength(defaultProps.options.length + 1)
 
   defaultProps.options.forEach((option) => {
     expect(screen.getByRole('option', { name: option.label })).toHaveValue(
@@ -64,4 +65,11 @@ it('shhould show error message if passed one', () => {
   const selectControl = screen.getByRole('combobox')
   expect(selectControl).toBeInvalid()
   expect(selectControl).toHaveAccessibleDescription(errorMessage)
+})
+it('should have empty value to start with', () => {
+  render(<Select {...defaultProps} />)
+
+  const selectControl = screen.getByRole('combobox')
+  expect(selectControl).toHaveDisplayValue('')
+  expect(within(selectControl).getByRole('option', { name: '' })).toBeDisabled()
 })

--- a/src/client/shared/components/select/select.tsx
+++ b/src/client/shared/components/select/select.tsx
@@ -1,17 +1,35 @@
 import { ForwardedRef, forwardRef } from 'react'
+import {
+  OptionHTMLAttributes,
+  SelectHTMLAttributes,
+} from 'hoist-non-react-statics/node_modules/@types/react'
 import { labelWrapper, select, wrapper } from './select.css'
 
-import { SelectHTMLAttributes } from 'hoist-non-react-statics/node_modules/@types/react'
 import { useId } from '@react-aria/utils'
 
 type Props = {
   label: string
   isLoading?: boolean
-  options?: Array<{ value: string; label?: string }>
+  options?: Array<Option>
   errorMessage?: string
 } & SelectHTMLAttributes<HTMLSelectElement>
 
-const loadingOption = { value: '', label: 'Loading...' }
+type Option = {
+  value: string
+  label?: string
+  optionProps?: OptionHTMLAttributes<HTMLOptionElement>
+}
+
+const loadingOption = {
+  value: '',
+  label: 'Loading...',
+  optionProps: { disabled: true },
+}
+const emptyOption = {
+  value: '',
+  label: '',
+  optionProps: { disabled: true },
+}
 
 export const Select = forwardRef(function Select(
   {
@@ -20,11 +38,12 @@ export const Select = forwardRef(function Select(
     options: optionsProp = [],
     errorMessage,
     className,
+    defaultValue = '',
     ...delegatedProps
   }: Props,
   ref: ForwardedRef<HTMLSelectElement>
 ): JSX.Element {
-  const options = isLoading ? [loadingOption] : optionsProp
+  const options = isLoading ? [loadingOption] : [emptyOption, ...optionsProp]
   const controlId = useId()
   const errorId = useId()
 
@@ -47,12 +66,17 @@ export const Select = forwardRef(function Select(
         className={select}
         id={controlId}
         ref={ref}
+        defaultValue={defaultValue}
         {...delegatedProps}
         aria-invalid={status === 'error'}
         aria-describedby={status === 'error' ? errorId : undefined}
       >
         {options.map((option) => (
-          <option key={option.value} value={option.value}>
+          <option
+            key={option.value}
+            value={option.value}
+            {...option.optionProps}
+          >
             {option.label ?? option.value}
           </option>
         ))}

--- a/src/client/shared/styles/global.css.ts
+++ b/src/client/shared/styles/global.css.ts
@@ -2,7 +2,6 @@ import { globalStyle } from '@vanilla-extract/css'
 import { themeVars } from './theme.css'
 
 globalStyle('body', {
-  overflowY: 'scroll',
   fontFamily: `'Spartan', sans-serif`,
   fontSize: themeVars.typography.body1.fontSize,
   lineHeight: themeVars.typography.body1.lineHeight,

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,7 @@ import Document, { Head, Html, Main, NextScript } from 'next/document'
 class MyDocument extends Document {
   render(): JSX.Element {
     return (
-      <Html>
+      <Html lang="en">
         <Head>
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link


### PR DESCRIPTION
if a filter is selected, then there are too many combinations of filters to be able to effectively
optimistically update all of them with the new/updated data. Instead, invalidate all the list
queries so they refecth. We can still optimistically update the non-filtered list, and the
individual detail page, so in many cases, the optimistic behaviour is preserved